### PR TITLE
http: superfluous response.WriteHeader call from github.com/JanStanleyWatt/hukubiki-api/api.jsonOutput (jsonIO.go:42)の解消

### DIFF
--- a/api/int64.go
+++ b/api/int64.go
@@ -19,7 +19,10 @@ func Int64n(w http.ResponseWriter, r *http.Request) {
 
 	// リクエストのボディをデコード、エラーがあればエラーレスポンスをJsonで返す
 	var in requestInt64n
-	jsonInput(w, r, &in)
+	if err := jsonInput(r, &in); err != nil {
+		jsonErrorOutput(w, http.StatusBadRequest, err)
+		return
+	}
 
 	// [0, Max)の範囲で乱数を生成。Maxが0以下の場合はエラーレスポンスを返す
 	if in.Max <= 0 {
@@ -27,10 +30,10 @@ func Int64n(w http.ResponseWriter, r *http.Request) {
 		jsonErrorOutput(w, http.StatusBadRequest, err)
 		return
 	}
-	j := responseInt64n{
+	out := responseInt64n{
 		RandomNumber: rand.New(rand.NewPCG(in.Seed[0], in.Seed[1])).Int64N(in.Max),
 	}
 
 	// レスポンスを返す
-	jsonOutput(w, j)
+	jsonOutput(w, out)
 }


### PR DESCRIPTION
Fixes #4